### PR TITLE
[bug] Android color bug fix

### DIFF
--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -22,16 +22,16 @@ const RED = "#ff0000";
 const BLUE = "#0000ff";
 
 const CRAWL_COLORS = [
-  "#45B8AC",
-  "#88B04B",
-  "#FFDD33",
-  "#955251",
-  "#013220",
-  "#B565A7",
-  "#998000",
-  "#6B5B95",
-  "#FF6F61",
-  "#F7CAC9"
+  "#45B8AC", // A
+  "#88B04B", // B
+  "#FFDD33", // C
+  "#013220", // D
+  "#955251", // E DOES NOT WORK
+  "#B565A7", // F
+  "#998000", // G
+  "#6B5B95", // H
+  "#FF6F61", // I
+  "#F7CAC9"  // J
 ];
 
 // Never expected to be used

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -22,22 +22,22 @@ const RED = "#ff0000";
 const BLUE = "#0000ff";
 
 const CRAWL_COLORS = [
-  "#45B8AC", // A
-  "#88B04B", // B
-  "#FFDD33", // C
-  "#013220", // D
-  "#955251", // E DOES NOT WORK
-  "#B565A7", // F
-  "#998000", // G
-  "#6B5B95", // H
-  "#FF6F61", // I
-  "#F7CAC9"  // J
+  "#45B8AC",
+  "#88B04B",
+  "#FFDD33",
+  "#013220",
+  "orange",
+  "#B565A7",
+  "linen",
+  "indigo",
+  "green",
+  "coral"
 ];
 
 // Never expected to be used
 // If it is it means we have over 10 clue lists
 // in which case we have bigger problems
-const OVERFLOW_COLOR = "#000000";
+const OVERFLOW_COLOR = "yellow";
 
 // Controls initial zoom of the map
 const LATITUDE_DELTA = 0.06;
@@ -276,11 +276,13 @@ export default class HomeScreen extends React.Component {
 
     const crawlColors = this.makeCrawlColorMap();
     return cluesToShow.map((clue, index) => {
+      const clueKey = `${clue.clueListId}${clue.clueNum}`
+      const clueColor = this.clueColor(clue, crawlColors);
       return (
         <Clue
+          key={`${clueKey}-${clueColor}`} // bug report that key needs to change for color to change on android
           clue={clue}
-          key={index}
-          color={this.clueColor(clue, crawlColors)}
+          color={clueColor}
           onCluePress={this.makeOnCluePress(clue)}
         />
       );


### PR DESCRIPTION
Colors are hard. Made marker keys very distinct by using the clue id (e.g. A12) and the color that the clue is being rendered with to make sure that color updates can happen correctly when a clue is marked completed and that the keys don't relate to other markers that may have existed in a different filtering of the clues.